### PR TITLE
Nav menu text alignment

### DIFF
--- a/docs/stylesheets/style.css
+++ b/docs/stylesheets/style.css
@@ -41,3 +41,12 @@ img#zone {
     border: 5px solid dimgray;
     border-radius: 10px;
 }
+
+.wy-menu-vertical .subnav a {
+    display: flex;
+    align-items: center;
+}
+
+.wy-menu-vertical .subnav a img {
+    margin-right: 5px;
+}

--- a/docs/stylesheets/style.css
+++ b/docs/stylesheets/style.css
@@ -43,10 +43,17 @@ img#zone {
 }
 
 .wy-menu-vertical .subnav a {
-    display: flex;
-    align-items: center;
+  padding-right:4px;
+  display: flex;
+  align-items: center;
 }
 
 .wy-menu-vertical .subnav a img {
-    margin-right: 5px;
+  order:-1;
+}
+
+.wy-menu-vertical .subnav a::before {
+  content: " ";
+  flex-basis: 5px;
+  order: 0;
 }


### PR DESCRIPTION
Before:

![screenshot_84](https://user-images.githubusercontent.com/10088628/71384361-e08b8a80-25ae-11ea-95bf-a31de6281abe.png)

After:

![screenshot_86](https://user-images.githubusercontent.com/10088628/71385081-42e68a00-25b3-11ea-8c74-ceaff3df89d5.png)

This works because flex elements can't overlap each other. Used a pseudo to solve alignment issues, with icons changing size as margin was applied to them.