### PR TITLE
Add repo_url to config file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: Mindustry Wiki
 site_url: https://mindustrygame.github.io/wiki/
+repo_url: https://github.com/MindustryGame/wiki
 theme: 
     name: readthedocs
     custom_dir: custom_theme/


### PR DESCRIPTION
If I understand [the documentation correctly][1], this should add an edit link on every page which links to the appropriate page edit form on GitHub. This should make it way easier for users to contribute to the wiki.

[1]: https://www.mkdocs.org/user-guide/configuration/#repo_url