### PR TITLE
Fix typo in the name of the game

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -27,7 +27,7 @@ If you have JRE already installed (which is recommended), you can also run `desk
 
 #### Play Store
 
-There are two different versions of Mindustry on the Play Store; Mindsutry and Mindustry Classic. If you want to get the latest releases of Mindustry, go get **Mindustry**. Otherwise, if you want the old classic version, you can get **Mindustry Classic**.
+There are two different versions of Mindustry on the Play Store; Mindustry and Mindustry Classic. If you want to get the latest releases of Mindustry, go get **Mindustry**. Otherwise, if you want the old classic version, you can get **Mindustry Classic**.
 
 #### F-Droid
 


### PR DESCRIPTION
I did see that some pages are auto generated but there is no link to the repo which generates these files.

EDIT: I just found the link in the closed issues and will add a PR for adding a link in the readme.