### PR TITLE
Fix grammer mistake

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -10,7 +10,7 @@ This is your typical, run-of-the-mill setup process.
 
 #### Steam 
 
-As of recent, you can now [buy the game on Steam](https://store.steampowered.com/app/1127400/) if you would like to support Anuke!
+As of recently, you can now [buy the game on Steam](https://store.steampowered.com/app/1127400/) if you would like to support Anuke!
 
 #### Itch.io
 


### PR DESCRIPTION
In the Getting Started page, there's a small grammar mistake where it uses "recent" instead of "recently". It's in "*As of **recent**, you can now buy the game on Steam if you would like to support Anuke!*"

I've fixed this in this pull request.