### PR TITLE
Mention outlines

### DIFF
--- a/docs/modding/4-spriting.md
+++ b/docs/modding/4-spriting.md
@@ -369,6 +369,9 @@ The process of drawing units can be roughly divided into 5 stages:
 
 > written by Zhenьkotron#9493, proofread by Geschiedenis#4783
 
+### **Outlines**
+Leave 4 pixels of space around the edges of turret sprites and unit sprites, as the game will use that space to automatically add outlines.
+
 ---
 
 ### **Evironmental Sprites**


### PR DESCRIPTION
Put the sprite to the edge, and the outline *will* be cut off.
~~There's probably a better place in the spriting guide to put that information.~~