### PR TITLE
Updated hyperlink for HJSON homepage

### DIFF
--- a/docs/modding/1-modding.md
+++ b/docs/modding/1-modding.md
@@ -41,7 +41,7 @@ Your project directory should look something like this:
 Every platform has a different user application data directory, and this is where your mods should be placed:
 
 -   Linux: `~/.local/share/Mindustry/mods/`
--   Steam: `steam/steamapps/common/Mindustry/mods/`
+-   Steam: `steam/steamapps/common/Mindustry/saves/mods/`
 -   Windows: `%appdata%/Mindustry/mods/`
 -   MacOS: `~/Library/Application Support/Mindustry/mods/`
 

--- a/docs/modding/1-modding.md
+++ b/docs/modding/1-modding.md
@@ -53,7 +53,7 @@ Every platform has a different user application data directory, and this is wher
 
 ## Hjson
 
-Mindustry uses [Hjson](https://hjson.org/), which for anyone who knows Json, is simply a superset of the very popular serialization language known as [Json](https://en.wikipedia.org/wiki/JSON). &#x2013; This means that any valid Json will work, but you get extra useful stuff:
+Mindustry uses [Hjson](https://hjson.github.io/), which for anyone who knows Json, is simply a superset of the very popular serialization language known as [Json](https://en.wikipedia.org/wiki/JSON). &#x2013; This means that any valid Json will work, but you get extra useful stuff:
 
     # single line comment
     


### PR DESCRIPTION
I noticed that the old HJSON hyperlink in the docs was out of date and updated it.