### PR TITLE
Add mlog-mode for Emacs to editors

### DIFF
--- a/docs/logic/2-editing.md
+++ b/docs/logic/2-editing.md
@@ -26,7 +26,11 @@ The advantages of manually editing code as opposed to the Visual Editor are:
 * Denser than the Visual Editor; more code can be seen at a time
 * Typing is faster than dragging-and-dropping across long walls of code
 * Can be used to make quick pieces of code for demonstration without opening Mindustry
-* Syntax highlighting in some editors, such as [VS Code (plugin)](https://marketplace.visualstudio.com/items?itemName=vortetty.mindustry-logic), [Emacs (package)](https://github.com/vednoc/masm-mode), [Vim (plugin)](https://github.com/purofle/vim-mindustry-logic), and [Sublime Text (package)](https://github.com/gigamicro/Mindustry4Sublime)
+* Syntax highlighting in some editors, such as:
+   * [VS Code (plugin)](https://marketplace.visualstudio.com/items?itemName=vortetty.mindustry-logic)
+   * Emacs (package): [mlog-mode](https://github.com/hey2022/mlog-mode) or [masm-mode](https://github.com/vednoc/masm-mode)
+   * [Vim (plugin)](https://github.com/purofle/vim-mindustry-logic)
+   * [Sublime Text (package)](https://github.com/gigamicro/Mindustry4Sublime)
 * A text block does not block part of the parameter text
 * Ability to save and access code outside of Mindustry
 


### PR DESCRIPTION
I tried out masm-mode for syntax highlighting in Emacs, but I found it lacking as it only highlighted the basic operators (it was also missing a few). I've created [mlog-mode](https://github.com/hey2022/mlog-mode) instead, which highlights all the operators, variables, blocks, units, etc.

I added a link to it in the editing part of the wiki and reorganized the structure using Markdown lists.