### PR TITLE
Add RGBA hex codes to Markup/built-in color tags

### DIFF
--- a/docs/modding/5-markup.md
+++ b/docs/modding/5-markup.md
@@ -28,37 +28,37 @@ Example:
 
 ### Built-in Colors
 
-    [clear]clear
-    [black]black
-    [white]white
-    [lightgray]lightgray
-    [gray]gray
-    [darkgray]darkgray
-    [blue]blue
-    [navy]navy
-    [royal]royal
-    [slate]slate
-    [sky]sky
-    [cyan]cyan
-    [teal]teal
-    [green]green
-    [acid]acid
-    [lime]lime
-    [forest]forest
-    [olive]olive
-    [yellow]yellow
-    [gold]gold
-    [goldenrod]goldenrod
-    [orange]orange
-    [brown]brown
-    [tan]tan
-    [brick]brick
-    [red]red
-    [scarlet]scarlet
-    [coral]coral
-    [salmon]salmon
-    [pink]pink
-    [magenta]magenta
-    [purple]purple
-    [violet]violet
-    [maroon]maroon
+    [clear]clear (#00000000)
+    [black]black (#000000FF)
+    [white]white (#FFFFFFFF)
+    [lightgray]lightgray (#BFBFBFFF)
+    [gray]gray (#7F7F7FFF)
+    [darkgray]darkgray (#3F3F3FFF)
+    [blue]blue (#0000FFFF)
+    [navy]navy (#00007FFF)
+    [royal]royal (#4169E1FF)
+    [slate]slate (#700090FF)
+    [sky]sky (#87CEEBFF)
+    [cyan]cyan (#00FFFFFF)
+    [teal]teal (#007F7FFF)
+    [green]green (#00FF00FF)
+    [acid]acid (#7FFF00FF)
+    [lime]lime (#32CD32FF)
+    [forest]forest (#228B22FF)
+    [olive]olive (#6B8E23FF)
+    [yellow]yellow (#FFFF00FF)
+    [gold]gold (#FFD700FF)
+    [goldenrod]goldenrod (#DAA520FF)
+    [orange]orange (#FFA500FF)
+    [brown]brown (#8B4513FF)
+    [tan]tan (#D2B48CFF)
+    [brick]brick (#B22222FF)
+    [red]red (#FF0000FF)
+    [scarlet]scarlet (#FF341CFF)
+    [coral]coral (#FF7F50FF)
+    [salmon]salmon (#FA8072FF)
+    [pink]pink (#FF69B4FF)
+    [magenta]magenta (#FF00FFFF)
+    [purple]purple (#8000FFFF)
+    [violet]violet (#EE82EEFF)
+    [maroon]maroon (#B03060FF)


### PR DESCRIPTION
This adds the full 8-digit hex RGBA codes next to each color name in the [color] tag list to improve clarity and assist modders in using accurate color values.